### PR TITLE
Feature/fix auth issues

### DIFF
--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -37,12 +37,11 @@ export function getAccessTokenFromRefresh() {
   return dispatch => {
     dispatch(accessTokenRequested());
 
-    tokenService.getAccessTokenFromRefreshToken().then(({ data, error }) => {
-      if (error) {
-        return dispatch(accessTokenFailure());
-      }
+    tokenService.getAccessTokenFromRefreshToken().then(response => {
+      const { error } = response;
+      if (error) throw error;
 
-      let { access_token } = data;
+      let { access_token } = response;
       dispatch(accessTokenRefreshed({ access_token }));
     });
   };
@@ -54,14 +53,13 @@ export function getAccessTokenFromCode(code) {
 
     tokenService
       .getAccessTokenFromCode(code)
-      .then(({ data, error }) => {
-        if (error) {
-          return dispatch(accessTokenFailure());
-        }
+      .then(response => {
+        const { error, error_description } = response;
+        if (error) throw new Error(error_description);
 
-        let { refresh_token, access_token } = data;
+        const { refresh_token, access_token } = response;
         dispatch(accessTokenSuccess({ access_token, refresh_token }));
       })
-      .catch(e => console.log(e));
+      .catch(e => console.error(e));
   };
 }

--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -58,6 +58,7 @@ export function getAccessTokenFromCode(code) {
         if (error) throw new Error(error_description);
 
         const { refresh_token, access_token } = response;
+        window.location.replace("/");
         dispatch(accessTokenSuccess({ access_token, refresh_token }));
       })
       .catch(e => console.error(e));

--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -38,10 +38,9 @@ export function getAccessTokenFromRefresh() {
     dispatch(accessTokenRequested());
 
     tokenService.getAccessTokenFromRefreshToken().then(response => {
-      const { error } = response;
+      const { error, access_token } = response;
       if (error) throw error;
 
-      let { access_token } = response;
       dispatch(accessTokenRefreshed({ access_token }));
     });
   };
@@ -54,10 +53,14 @@ export function getAccessTokenFromCode(code) {
     tokenService
       .getAccessTokenFromCode(code)
       .then(response => {
-        const { error, error_description } = response;
+        const {
+          error,
+          error_description,
+          refresh_token,
+          access_token
+        } = response;
         if (error) throw new Error(error_description);
 
-        const { refresh_token, access_token } = response;
         window.location.replace("/");
         dispatch(accessTokenSuccess({ access_token, refresh_token }));
       })

--- a/src/actions/tracks.js
+++ b/src/actions/tracks.js
@@ -7,28 +7,33 @@ let currentTrackID = 0;
 export function getCurrentTrack() {
   return dispatch => {
     dispatch(trackRequested());
-    spotifyService.getCurrentTrack()
+    spotifyService
+      .getCurrentTrack()
       .then(response => {
+        let { item, error } = response;
+        if (error) throw error;
+
         if (currentTrackID !== response.data.item.id) {
           dispatch(getCurrentTrackSuccess(response));
           currentTrackID = response.data.item.id;
         }
       })
       .catch(err => {
+        console.log(err);
         throw Error("Error fetching current track");
       });
-  }
+  };
 }
 
 export function trackRequested() {
   return {
     type: actionTypes.TRACK_REQUEST
-  }
+  };
 }
 
 export function getCurrentTrackSuccess(track) {
   return {
-	  type: actionTypes.TRACK_CHANGED,
+    type: actionTypes.TRACK_CHANGED,
     track: track.data
-  }
+  };
 }

--- a/src/actions/tracks.js
+++ b/src/actions/tracks.js
@@ -13,14 +13,14 @@ export function getCurrentTrack() {
         let { item, error } = response;
         if (error) throw error;
 
-        if (currentTrackID !== response.data.item.id) {
+        if (currentTrackID !== item.id) {
           dispatch(getCurrentTrackSuccess(response));
-          currentTrackID = response.data.item.id;
+          currentTrackID = item.id;
         }
       })
       .catch(err => {
         console.log(err);
-        throw Error("Error fetching current track");
+        dispatch(getCurrentTrackFailure());
       });
   };
 }
@@ -34,6 +34,12 @@ export function trackRequested() {
 export function getCurrentTrackSuccess(track) {
   return {
     type: actionTypes.TRACK_CHANGED,
-    track: track.data
+    track
+  };
+}
+
+export function getCurrentTrackFailure() {
+  return {
+    type: actionTypes.TRACK_REQUEST_FAILURE
   };
 }

--- a/src/components/Login/index.js
+++ b/src/components/Login/index.js
@@ -1,8 +1,18 @@
 import React from "react";
+import queryString from "query-string";
+
+let options = {
+  client_id: "4ea54ce3001542bdb54efbff4e75c91b",
+  response_type: "code",
+  redirect_uri: "http://localhost:3000/cb",
+  scope: "user-read-currently-playing user-read-playback-state"
+};
 
 export default () => (
   <a
-    href="https://accounts.spotify.com/authorize?client_id=4ea54ce3001542bdb54efbff4e75c91b&amp;response_type=code&amp;redirect_uri=http://localhost:3000/cb"
+    href={
+      `https://accounts.spotify.com/authorize?${queryString.stringify(options)}`
+    }
   >
     Login to Spotify
   </a>

--- a/src/containers/App/index.js
+++ b/src/containers/App/index.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import { connect } from "react-redux";
-import Helmet from 'react-helmet';
+import Helmet from "react-helmet";
 import styles from "./style.scss";
 import * as authActions from "../../actions/auth";
 import * as trackActions from "../../actions/tracks";
@@ -23,26 +23,30 @@ class App extends Component {
       }
     }
   }
-
-  pollSpotifyAPI() {
-    setTimeout(() => {
-      this.props.getCurrentTrack();
-      this.pollSpotifyAPI();
-    }, 5000);
-  }
+  //
+  // pollSpotifyAPI() {
+  //   setTimeout(() => {
+  //     this.props.getCurrentTrack();
+  //     this.pollSpotifyAPI();
+  //   }, 5000);
+  // }
 
   render() {
     if (this.props.accessToken) {
-      this.pollSpotifyAPI();
+      this.props.getCurrentTrack();
     }
 
     const { item } = this.props.currentTrack;
-    const title = item ? `${item.name} - ${item.artists[0].name}` : "Login - Now Playing";
+    const title = item
+      ? `${item.name} - ${item.artists[0].name}`
+      : "Login - Now Playing";
 
     return (
       <div className={styles.app}>
         <Helmet title={title} />
-        {this.props.accessToken && this.props.currentTrack.item ? <Track track={this.props.currentTrack} /> : <Login />}
+        {this.props.accessToken && this.props.currentTrack.item
+          ? <Track track={this.props.currentTrack} />
+          : <Login />}
       </div>
     );
   }
@@ -61,8 +65,7 @@ const mapDispatchToProps = dispatch => {
       dispatch(authActions.getAccessTokenFromCode(code)),
     getAccessTokenFromRefresh: () =>
       dispatch(authActions.getAccessTokenFromRefresh()),
-    getCurrentTrack: () =>
-      dispatch(trackActions.getCurrentTrack())
+    getCurrentTrack: () => dispatch(trackActions.getCurrentTrack())
   };
 };
 

--- a/src/containers/App/index.js
+++ b/src/containers/App/index.js
@@ -23,13 +23,16 @@ class App extends Component {
       }
     }
   }
-  //
-  // pollSpotifyAPI() {
-  //   setTimeout(() => {
-  //     this.props.getCurrentTrack();
-  //     this.pollSpotifyAPI();
-  //   }, 5000);
-  // }
+
+  pollSpotifyAPI() {
+    setTimeout(
+      () => {
+        this.props.getCurrentTrack();
+        this.pollSpotifyAPI();
+      },
+      5000
+    );
+  }
 
   render() {
     if (this.props.accessToken) {

--- a/src/containers/App/index.js
+++ b/src/containers/App/index.js
@@ -12,6 +12,9 @@ import Login from "../../components/Login";
 class App extends Component {
   componentDidMount() {
     this.getTokenFromCallbackHandler();
+    if (this.props.accessToken) {
+      this.pollSpotifyAPI();
+    }
   }
 
   getTokenFromCallbackHandler() {
@@ -25,9 +28,9 @@ class App extends Component {
   }
 
   pollSpotifyAPI() {
+    this.props.getCurrentTrack();
     setTimeout(
       () => {
-        this.props.getCurrentTrack();
         this.pollSpotifyAPI();
       },
       5000
@@ -35,10 +38,6 @@ class App extends Component {
   }
 
   render() {
-    if (this.props.accessToken) {
-      this.props.getCurrentTrack();
-    }
-
     const { item } = this.props.currentTrack;
     const title = item
       ? `${item.name} - ${item.artists[0].name}`

--- a/src/reducers/tracks.js
+++ b/src/reducers/tracks.js
@@ -10,6 +10,9 @@ export default function tracks(state = initialState, action) {
     case actionTypes.TRACK_CHANGED:
       state.previousTracks.push(state.currentTrack);
       return { ...state, currentTrack: action.track };
+    case actionTypes.TRACK_REQUEST_FAILURE:
+      // Do API error handling here
+      return { ...state };
     default:
       return state;
   }

--- a/src/services/spotify.js
+++ b/src/services/spotify.js
@@ -1,27 +1,18 @@
 import { SPOTIFY_ACCESS_TOKEN } from "../constants/storage-keys";
 
 export default class SpotifyService {
+  apiURL = "https://api.spotify.com/v1/me/player/currently-playing";
 
-	apiURL = 'https://api.spotify.com/v1/me/player/currently-playing';
-
-	getCurrentTrack() {
-		const accessToken = localStorage.getItem(SPOTIFY_ACCESS_TOKEN);
-		return fetch(`${this.apiURL}`, {
-			method: "GET",
-			headers: {
-				"Content-Type": "application/x-www-form-urlencoded",
-				"Authorization": `Bearer ${accessToken}`
-			}
-		})
-		.then(response => {
-			if (!response.ok) {
-			  throw Error(response.statusText);
-			}
-			return response;
-		})
-		.then(response => response.json())
-		.then(response => ({ data: response }))
-		.catch(e => ({ error: e }));
-	}
-
+  getCurrentTrack() {
+    const accessToken = localStorage.getItem(SPOTIFY_ACCESS_TOKEN);
+    return fetch(`${this.apiURL}`, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Authorization: `Bearer ${accessToken}`
+      }
+    })
+      .then(response => response.json())
+      .catch(error => console.log(error));
+  }
 }

--- a/src/services/token.js
+++ b/src/services/token.js
@@ -9,16 +9,8 @@ export default class TokenService {
       headers: { "Content-Type": "application/x-www-form-urlencoded" },
       body: `code=${code}`
     })
-      .then(response => {
-        if (!response.ok) {
-          console.log("not okay hun");
-          throw Error(response.statusText);
-        }
-        return response;
-      })
       .then(response => response.json())
-      .then(response => ({ data: response }))
-      .catch(e => ({ error: e }));
+      .catch(error => console.log(error));
   }
 
   getAccessTokenFromRefreshToken() {
@@ -27,16 +19,6 @@ export default class TokenService {
       method: "POST",
       headers: { "Content-Type": "application/x-www-form-urlencoded" },
       body: `refresh_token=${refresh_token}`
-    })
-      .then(response => {
-        if (!response.ok) {
-          console.log("not okay hun");
-          throw Error(response.statusText);
-        }
-        return response;
-      })
-      .then(response => response.json())
-      .then(response => ({ data: response }))
-      .catch(e => ({ error: e }));
+    }).then(response => response.json());
   }
 }


### PR DESCRIPTION
The Spotify API returns error keys in the response object so we can check against these instead of throwing errors ourselves, so I've simplified the promise logic to account for this. Turns out I needed to add a couple of scopes to get access to the currently playing track (which is why it wasn't working on my local machine) so I've added those. Also cleaned up a few bits to do with the oauth callback logic and made it so the track is fetched from the API straight away.